### PR TITLE
Add `intrinsicsize`

### DIFF
--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -1027,6 +1027,56 @@
               "deprecated": false
             }
           }
+        },
+        "intrinsicsize": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "71"
+              },
+              "chrome_android": {
+                "version_added": "71"
+              },
+              "edge": {
+                "version_added": null
+              },
+              "edge_mobile": {
+                "version_added": null
+              },
+              "firefox": {
+                "version_added": null
+              },
+              "firefox_android": {
+                "version_added": null
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": "58"
+              },
+              "opera_android": {
+                "version_added": "58"
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": null
+              },
+              "webview_android": {
+                "version_added": "71"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Experimental `intrinsicsize` attribute added.
Explainer: https://github.com/ojanvafai/intrinsicsize-attribute

Chrome: `Experimental Web Platform features` flag, Version >= Chrome 71. https://www.chromestatus.com/feature/4704436815396864
Firefox: No public signals
Edge: No public signals
Safari: No public signals
Web Developers: No signals